### PR TITLE
Use `vyos_ntp_global` to manage NTP servers

### DIFF
--- a/vyos.yml
+++ b/vyos.yml
@@ -20,21 +20,23 @@
         name_servers: "{{ vyos_system__name_servers }}"
       tags:
         - "dns"
-    - name: "Remove default NTP servers"
+    - name: Set Timezone
       vyos.vyos.vyos_config:
         lines:
-          - "delete system ntp server {{ item }}"
-      loop:
-        - "0.pool.ntp.org"
-        - "1.pool.ntp.org"
-        - "2.pool.ntp.org"
-      when: item in ansible_net_config[0]
-    - name: "Set NTP servers"
-      vyos.vyos.vyos_config:
-        lines:
-          - "set system ntp server {{ common__ntp_pool }} pool"
-          - "set system time-zone US/Pacific"
+          - set system time-zone US/Pacific
         save: true
+      tags:
+        - time
+    - name: Set NTP servers
+      vyos.vyos.vyos_ntp_global:
+        config:
+          servers:
+            - server: "{{ common__ntp_pool }}"
+              options:
+                - pool
+        state: replaced
+      tags:
+        - time
 
     #
     # Interfaces


### PR DESCRIPTION
This would work, but there's a [bug with the module and pools](https://github.com/ansible-collections/vyos.vyos/issues/221), so it doesn't work in practice.

Stashing this work in a PR so I can come back to it when it's fixed.