### PR TITLE
Use Just for renovate-validate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "earthly.earthfile-syntax-highlighting"
+                "earthly.earthfile-syntax-highlighting",
+                "nefrob.vscode-just-syntax"
             ],
             "settings": {
                 "yaml.customTags": [
@@ -41,6 +42,10 @@
             "bootstrap": true,
             // renovate: datasource=docker depName=earthly/earthly
             "version": "v0.8.15"
+        },
+        "ghcr.io/guiyomh/features/just:0": {
+            // renovate: datasource=github-releases depName=casey/just
+            "version": "1.38.0"
         },
         "ghcr.io/marcozac/devcontainer-features/shellcheck:1": {
             // renovate: datasource=github-releases depName=koalaman/shellcheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,6 @@ jobs:
           imageName: ghcr.io/${{ github.repository }}-devcontainer
           push: filter
           refFilterForPush: refs/heads/main
-          runCmd: earthly +lint
+          runCmd: |
+            earthly +lint
+            just renovate-validate

--- a/Earthfile
+++ b/Earthfile
@@ -46,14 +46,6 @@ kustomize-build:
     COPY kustomization kustomization
     RUN find kustomization/overlays/prod/ -mindepth 1 -maxdepth 1 -type d -print | xargs -r -n1 kustomize build --enable-helm > /dev/null
 
-renovate-validate:
-    # renovate: datasource=docker depName=renovate/renovate versioning=docker
-    ARG RENOVATE_VERSION=39
-    FROM renovate/renovate:$RENOVATE_VERSION
-    WORKDIR /usr/src/app
-    COPY renovate.json .
-    RUN renovate-config-validator
-
 shellcheck-lint:
     # renovate: datasource=docker depName=koalaman/shellcheck-alpine versioning=docker
     ARG SHELLCHECK_VERSION=v0.10.0
@@ -65,5 +57,4 @@ shellcheck-lint:
 lint:
     BUILD +hadolint
     BUILD +kustomize-build
-    BUILD +renovate-validate
     BUILD +shellcheck-lint

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+# Lists all targets
+default:
+    just --list
+
+# Validate renovate.json file
+renovate-validate:
+    renovate-config-validator


### PR DESCRIPTION
Earthly appears to be unmaintained.  Just works great, and ends up being faster with the devcontainer anyway.